### PR TITLE
RTMP Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the ffmpeg MediaMTX image because it is based on alpine linux.
-FROM bluenviron/mediamtx:1.12.0-ffmpeg
+FROM bluenviron/mediamtx:1.12.2-ffmpeg
 
 # In testing, gst-rtsp-server was unable to be installed from APK on the MediaMTX image.
 # Build GStreamer & plugins from source according to https://gitlab.freedesktop.org/gstreamer/gstreamer
@@ -13,6 +13,7 @@ RUN apk update && apk add --no-cache \
     py3-setuptools \
     python3 \
     python3-dev \
+    rtmpdump-dev \
     # Installing as a meson subproject of GStreamer is borked.
     x264-dev
 
@@ -20,12 +21,8 @@ RUN git clone https://gitlab.freedesktop.org/gstreamer/gstreamer.git \
     && cd gstreamer \
     && git checkout 1.26.1 \
     && meson setup \
-        # Needed in order to build the x264 plugin.
+        # Enables the x264 plugin, among others.
         -Dgpl=enabled \
-        # Needed in order to build the ugly plugins.
-        -Dugly=enabled \
-        # x264 is part of the ugly plugins.
-        -Dgst-plugins-ugly:x264=enabled \
         # Encountered build issues with avtp enabled.
         -Dgst-plugins-bad:avtp=disabled \
         build \


### PR DESCRIPTION
This PR accomplishes the following:

- Adds support for `rtmp` plugins by adding the `rtmpdump-dev` dependency.
- Upgrades the `medimtx` base container version from 1.12.0 -> 1.12.2.
- Simplifies the `meson setup` instructions in the `Dockerfile`.