### PR TITLE
Fix gst-plugin-scanner logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,9 @@ RUN apk update && apk add --no-cache \
     git \
     linux-headers \
     meson \
-    py3-setuptools \
-    python3 \
-    python3-dev \
     rtmpdump-dev \
+    libxml2 \
+    libxml2-dev \
     # Installing as a meson subproject of GStreamer is borked.
     x264-dev
 


### PR DESCRIPTION
This PR eliminates logs output by `gst-plugin-scanner` when a GStreamer pipeline is started. This is done by removing Python from the Dockerfile and adding libxml2. Removing Python makes it so that GStreamer Python bindings cannot be used in a GMTX container.

Starting pipeline on `master`.
![image](https://github.com/user-attachments/assets/16ba910a-a026-4e09-9cf5-ba18ba9fc7a0)

Starting pipeline on this branch.
![image](https://github.com/user-attachments/assets/2aea35f7-9a00-421a-8984-453d02d2ece0)
